### PR TITLE
ignore lower 2 bits off CLA, prefix refresh response with TAG 0xDF20

### DIFF
--- a/aram/src/main/java/fr/bmartel/aram/AccessRuleMaster.java
+++ b/aram/src/main/java/fr/bmartel/aram/AccessRuleMaster.java
@@ -77,7 +77,7 @@ public class AccessRuleMaster extends Applet implements Application {
 
         byte[] buffer = apdu.getBuffer();
 
-        if (buffer[ISO7816.OFFSET_CLA] != (byte) 0x80) {
+        if (((byte) (buffer[ISO7816.OFFSET_CLA] & (byte) 0xFC)) != (byte) 0x80 ) {
             ISOException.throwIt(ISO7816.SW_CLA_NOT_SUPPORTED);
         }
 
@@ -216,8 +216,12 @@ public class AccessRuleMaster extends Applet implements Application {
 
         byte[] buf = APDU.getCurrentAPDUBuffer();
 
-        Util.arrayCopy(refreshTag, (short) 0, buf, (short) 0, (short) 8);
-        APDU.getCurrentAPDU().setOutgoingAndSend((short) 0, (short) 8);
+        buf[0] = (byte) 0xDF;
+        buf[1] = (byte) 0x20;
+        buf[2] = (byte) 8;
+
+        Util.arrayCopy(refreshTag, (short) 0, buf, (short) 3, (short) 8);
+        APDU.getCurrentAPDU().setOutgoingAndSend((short) 0, (short) 11);
     }
 
     /**


### PR DESCRIPTION
When checking the class byte the two lower bits should be ignored, see https://github.com/seek-for-android/hello-smartcard-jc-applet/blob/master/src/com/gieseckedevrient/javacard/hellosmartcard/HelloSmartcard.java

The response tag of refresh should countain the TAG 0xDF20
