### PR TITLE
implement 'delete all rules' 0xF1 0x00

### DIFF
--- a/aram/src/main/java/fr/bmartel/aram/AccessRuleMaster.java
+++ b/aram/src/main/java/fr/bmartel/aram/AccessRuleMaster.java
@@ -324,8 +324,10 @@ public class AccessRuleMaster extends Applet implements Application {
         short ofs = ISO7816.OFFSET_CDATA;
 
         checkTLV(buf, ofs, (byte) 0xF1, (short) (6 + RuleEntry.SIZE_AID + RuleEntry.SIZE_HASH + RuleEntry.SIZE_RULE));
-
-        if (buf[(short) (ofs + 2)] == (byte) 0x4F) {
+        if (buf[(short) (ofs + 1)] == 0) {
+            //delete all rules if length == 0
+            RuleEntry.deleteAll();
+        } else if (buf[(short) (ofs + 2)] == (byte) 0x4F) {
             //delete AID-REF-DO
             checkTLV(buf, (short) (ofs + 2), (byte) 0x4F, RuleEntry.SIZE_AID);
             short ofsAidRefDo = (short) (ofs + 2);

--- a/aram/src/main/java/fr/bmartel/aram/RuleEntry.java
+++ b/aram/src/main/java/fr/bmartel/aram/RuleEntry.java
@@ -176,11 +176,12 @@ public class RuleEntry {
      */
     static void deleteAll() {
         JCSystem.beginTransaction();
-        RuleEntry re = getFirst();
+
+        RuleEntry re = first;
         while (re != null) {
             re.remove();
             re.recycle();
-            re = re.getNext();
+            re = first;
         }
         JCSystem.commitTransaction();
     }

--- a/aram/src/main/java/fr/bmartel/aram/RuleEntry.java
+++ b/aram/src/main/java/fr/bmartel/aram/RuleEntry.java
@@ -171,6 +171,21 @@ public class RuleEntry {
     }
 
     /**
+     * delete all rules
+     *
+     */
+    static void deleteAll() {
+        JCSystem.beginTransaction();
+        RuleEntry re = getFirst();
+        while (re != null) {
+            re.remove();
+            re.recycle();
+            re = re.getNext();
+        }
+        JCSystem.commitTransaction();
+    }
+
+    /**
      * delete by aid.
      *
      * @param buf apdu buffer


### PR DESCRIPTION
When Command-Delete has length 0 all rules should be deleted (page 55 of Secure Element Access Control – Public Release v1.1).

